### PR TITLE
Adding Learning Objective to Dialectic

### DIFF
--- a/src/client/grpcClient.ts
+++ b/src/client/grpcClient.ts
@@ -30,7 +30,11 @@ import {
   PreprocessQuestionAnswerRequest,
   PreprocessQuestionAnswerResponse,
 } from '../generated/proto/epistemic_me_pb';
-import { DialecticType, UserAnswer } from '../generated/proto/models/dialectic_pb';
+import { 
+  DialecticType, 
+  UserAnswer,
+  LearningObjective 
+} from '../generated/proto/models/dialectic_pb';
 
 function apiKeyInterceptor(apiKey?: string): Interceptor {
   return (next) => async (req) => {
@@ -168,12 +172,14 @@ export class EpistemicMeClient implements IEpistemicMeClient {
   async createDialectic(params: {
     userId: string;
     dialecticType: DialecticType;
+    learningObjective?: LearningObjective;
   }): Promise<CreateDialecticResponse> {
     this.validateApiKey();
     
     const request = new CreateDialecticRequest({
       selfModelId: params.userId,
-      dialecticType: params.dialecticType
+      dialecticType: params.dialecticType,
+      learningObjective: params.learningObjective
     });
 
     try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ export {
   STATUS as DialecticStatus,
   InteractionType,
   QuestionAnswerInteraction,
+  LearningObjective,
 } from './generated/proto/models/dialectic_pb';
 
 export {


### PR DESCRIPTION
The PR adds a Learning Objective to a Dialectic. It is intended to move the SDK towards a modality of Dialectic design where the Developer can specify what they want to learn about their users, and then train a Question-Answer Dialectic to ask questions of their user until the LearningObjective for the dialectic is complete.

The Learning Objective can specify the BeliefType it needs to collect in order to fulfill the learning specification of the Dialectic.