### PR TITLE
Update philosophy with extrapolate context

### DIFF
--- a/src/client/grpcClient.ts
+++ b/src/client/grpcClient.ts
@@ -29,6 +29,10 @@ import {
   AddPhilosophyResponse,
   PreprocessQuestionAnswerRequest,
   PreprocessQuestionAnswerResponse,
+  CreatePhilosophyRequest,
+  CreatePhilosophyResponse,
+  UpdatePhilosophyRequest,
+  UpdatePhilosophyResponse,
 } from '../generated/proto/epistemic_me_pb';
 import { 
   DialecticType, 
@@ -69,6 +73,15 @@ export interface IEpistemicMeClient {
     philosophyId: string;
   }): Promise<AddPhilosophyResponse>;
   preprocessQuestionAnswer(questionBlob: string, answerBlob: string): Promise<PreprocessQuestionAnswerResponse>;
+  createPhilosophy(params: {
+    description: string;
+    extrapolateContexts?: boolean;
+  }): Promise<CreatePhilosophyResponse>;
+  updatePhilosophy(params: {
+    philosophyId: string;
+    description: string;
+    extrapolateContexts?: boolean;
+  }): Promise<UpdatePhilosophyResponse>;
 }
 
 export class EpistemicMeClient implements IEpistemicMeClient {
@@ -335,6 +348,42 @@ export class EpistemicMeClient implements IEpistemicMeClient {
       return await this.client.preprocessQuestionAnswer(request);
     } catch (error) {
       console.error("Error preprocessing Q&A:", error);
+      throw error;
+    }
+  }
+
+  async createPhilosophy(params: {
+    description: string;
+    extrapolateContexts?: boolean;
+  }): Promise<CreatePhilosophyResponse> {
+    this.validateApiKey();
+    const request = new CreatePhilosophyRequest({
+      description: params.description,
+      extrapolateContexts: params.extrapolateContexts ?? false,
+    });
+    try {
+      return await this.client.createPhilosophy(request);
+    } catch (error) {
+      console.error('Error creating philosophy:', error);
+      throw error;
+    }
+  }
+
+  async updatePhilosophy(params: {
+    philosophyId: string;
+    description: string;
+    extrapolateContexts?: boolean;
+  }): Promise<UpdatePhilosophyResponse> {
+    this.validateApiKey();
+    const request = new UpdatePhilosophyRequest({
+      philosophyId: params.philosophyId,
+      description: params.description,
+      extrapolateContexts: params.extrapolateContexts ?? false,
+    });
+    try {
+      return await this.client.updatePhilosophy(request);
+    } catch (error) {
+      console.error('Error updating philosophy:', error);
       throw error;
     }
   }

--- a/tests/self-model.test.ts
+++ b/tests/self-model.test.ts
@@ -142,4 +142,50 @@ describe('SelfModel Integration Tests', () => {
 
     expect(response.updatedSelfModel.philosophies).toContain('phil_105');
   });
+
+  test('create philosophy', async () => {
+    // Create a philosophy
+    const createResponse = await client.createPhilosophy({
+      description: '# Test Philosophy\n\n## Narrative\n[[C: Context1]] [[S: state1]] → [[S: state2]]',
+      extrapolateContexts: true
+    });
+
+    expect(createResponse).toBeDefined();
+    expect(createResponse.philosophy).toBeDefined();
+    expect(createResponse.philosophy?.description).toBe('# Test Philosophy\n\n## Narrative\n[[C: Context1]] [[S: state1]] → [[S: state2]]');
+    // New assertions for observation contexts
+    expect(createResponse.extrapolatedObservationContexts).toBeDefined();
+    expect(Array.isArray(createResponse.extrapolatedObservationContexts)).toBe(true);
+    expect(createResponse.extrapolatedObservationContexts.length).toBeGreaterThan(0);
+    const contextNames = createResponse.extrapolatedObservationContexts.map((ctx: any) => ctx.name);
+    expect(contextNames).toEqual(expect.arrayContaining(['Context1', 'state1', 'state2']));
+  });
+
+  test('update philosophy', async () => {
+    // First create a philosophy
+    const createResponse = await client.createPhilosophy({
+      description: '# UpdateMe\n\n## Narrative\n[[C: ContextA]] [[S: stateA]] → [[S: stateB]]',
+      extrapolateContexts: false
+    });
+    const philosophyId = createResponse.philosophy?.id;
+    expect(philosophyId).toBeDefined();
+
+    // Now update the philosophy
+    const updateResponse = await client.updatePhilosophy({
+      philosophyId: philosophyId!,
+      description: '# Updated Philosophy\n\n## Narrative\n[[C: Context2]] [[S: state3]] → [[S: state4]]',
+      extrapolateContexts: true
+    });
+
+    expect(updateResponse).toBeDefined();
+    expect(updateResponse.philosophy).toBeDefined();
+    expect(updateResponse.philosophy?.description).toBe('# Updated Philosophy\n\n## Narrative\n[[C: Context2]] [[S: state3]] → [[S: state4]]');
+    expect(updateResponse.philosophy?.id).toBe(philosophyId);
+    // New assertions for observation contexts
+    expect(updateResponse.extrapolatedObservationContexts).toBeDefined();
+    expect(Array.isArray(updateResponse.extrapolatedObservationContexts)).toBe(true);
+    expect(updateResponse.extrapolatedObservationContexts.length).toBeGreaterThan(0);
+    const updateContextNames = updateResponse.extrapolatedObservationContexts.map((ctx: any) => ctx.name);
+    expect(updateContextNames).toEqual(expect.arrayContaining(['Context2', 'state3', 'state4']));
+  });
 }); 


### PR DESCRIPTION
## Typescript SDK: Philosophy Methods & Tests Enhancement

### Overview

This PR introduces and tests new client methods for managing philosophies in the Epistemic-Me Typescript SDK. It also improves test coverage for observation context extraction.

### What’s New

- **Implemented Methods:**
  - `createPhilosophy`: Allows creation of a new philosophy with description and context extrapolation.
  - `updatePhilosophy`: Enables updating an existing philosophy’s description and context extrapolation flag.

- **Test Enhancements:**
  - Added integration tests for both `createPhilosophy` and `updatePhilosophy`.
  - Tests now assert that `extrapolatedObservationContexts` are correctly returned and parsed from the philosophy description.
  - Context names are checked to ensure correct extraction from narrative markup.

- **Code Quality:**
  - All changes follow project TypeScript, ESLint, and testing standards.
  - No linter or type errors; all tests pass.

### Motivation

- Completes the SDK’s support for philosophy management, aligning with backend and Python SDK features.
- Ensures robust, regression-safe handling of observation context extraction.
- Improves developer confidence and documentation for SDK consumers.

### Checklist

- [x] New client methods implemented and documented
- [x] Integration tests added and passing
- [x] Observation context extraction validated in tests
- [x] Code adheres to project rules and linting standards

